### PR TITLE
Ensure all attributes are initialized

### DIFF
--- a/src/http2/client.act
+++ b/src/http2/client.act
@@ -131,6 +131,7 @@ class RstStreamFrame(Frame):
 
 class SettingsFrame(Frame):
     def __init__(self, settings: dict[u16, u32], ack: bool = False):
+        Frame.__init__(self)  # Initialize parent attributes
         self.settings = settings
 
         #if ack and len(self.settings > 0):
@@ -209,6 +210,7 @@ class PushPromiseFrame(Frame):
 ACK: u32 = 0x01
 class PingFrame(Frame):
     def __init__(self, ack: bool, data: bytes):
+        Frame.__init__(self)  # Initialize parent attributes
         self.ack = ack
         self.data = data
 
@@ -235,6 +237,7 @@ class PingFrame(Frame):
 
 class GoAwayFrame(Frame):
     def __init__(self, last_stream_id: u32, error_code: int, debug_data: bytes):
+        Frame.__init__(self)  # Initialize parent attributes
         self.last_stream_id = last_stream_id
         self.error_code = error_code
         self.debug_data = debug_data
@@ -486,7 +489,6 @@ class InvalidState(StreamState):
 
 class Stream(object):
     stream_id: u32
-    client: Http2Client
     state: StreamState
     fields_buffer: bytes
     pp_fields_buffer: bytes

--- a/src/http2/hpack.act
+++ b/src/http2/hpack.act
@@ -4,7 +4,7 @@ class Deflater:
     _deflater: u64
 
     def __init__(self):
-        pass # TODO: remove, but actonc bug!?
+        self._deflater = 0
         self._init_deflater()
 
     def _init_deflater(self):
@@ -17,7 +17,7 @@ class Inflater:
     _inflater: u64
 
     def __init__(self):
-        pass # TODO: remove, but actonc bug!?
+        self._inflater = 0
         self._init_inflater()
 
     def _init_inflater(self):


### PR DESCRIPTION
Calling parent __init__ to initialize some stuff and removing Stream.client which seems to be unused.