### PR TITLE
Return HPACK deflate output with its actual length

### DIFF
--- a/src/hpack.ext.c
+++ b/src/hpack.ext.c
@@ -85,16 +85,15 @@ B_bytes http2Q_hpackQ_DeflaterD_deflate(http2Q_hpackQ_Deflater self, B_dict head
 
     nghttp2_ssize deflate_ret = nghttp2_hd_deflate_hd2(deflater, buf, buflen, nvs, numheaders);
 
-    if (deflate_ret < 0) {
-        buf[0] = 0;
-    }
-    else {
-        buf[buflen] = 0;
-    }
+    // HPACK output is binary and routinely contains NUL bytes, so it must be
+    // returned with its actual length (nghttp2_hd_deflate_hd2 returns the number
+    // of bytes written) rather than as a NUL-terminated C string, which would
+    // truncate the header block at the first 0x00.
+    int out_len = (deflate_ret < 0) ? 0 : (int)deflate_ret;
 
     acton_free(nvs);
 
-    return to$bytes((char*)buf);
+    return to$bytesD_len((char*)buf, out_len);
 }
 
 B_dict http2Q_hpackQ_InflaterD_inflate(http2Q_hpackQ_Inflater self, B_bytes compressed_headers) {


### PR DESCRIPTION
The HPACK deflater returned nghttp2's output via to$bytes((char*)buf), which treats the buffer as a NUL-terminated C string. HPACK header blocks are binary and routinely contain 0x00 bytes, so the block was being truncated at the first NUL. The result was a short HEADERS frame missing most of its fields, which strict HTTP/2 servers reject with "failed parsing HTTP/2". I hit this connecting an Acton gNMI client to Nokia SR Linux, whose Go gRPC server rejected every request until this was fixed.

This returns the buffer with the length nghttp2_hd_deflate_hd2 reports, via to$bytesD_len, so the whole header block is sent. More generally, any C ext returning binary bytes should use to$bytesD_len rather than to$bytes, which stops at the first NUL.