### PR TITLE
Drain the whole send queue instead of skipping frames

### DIFF
--- a/src/client.act
+++ b/src/client.act
@@ -815,8 +815,8 @@ actor Http2Client(cap: net.TCPConnectCap, address: str, port: int, on_connect: a
     def _send_frames():
         logger.debug('Send queue:', {'send_queue': send_queue})
         deferred_frames: list[Frame] = []
-        for frame in send_queue:
-            send_queue.pop(0)
+        while len(send_queue) > 0:
+            frame = send_queue.pop(0)
             if isinstance(frame, DataFrame):
                 length = len(frame.data)
                 if (length < connection_window and


### PR DESCRIPTION
_send_frames iterated send_queue while pop(0)-ing the front, which skips every other element and leaves frames unsent. Among the dropped frames are the WINDOW_UPDATE frames queued for each received DATA frame, so the HTTP/2 receive window is not reliably replenished and a server stalls once it has consumed the initial 65535-byte window - about 50 messages on a long-lived server stream. Drain with a while/pop loop so every queued frame is sent, deferred DATA frames excepted, keeping the flow-control window open. Verified with a gNMI streaming subscription against Nokia SR Linux: it previously stalled at ~50 notifications and now streams continuously.